### PR TITLE
Bug/6801 fix exit code for external commands

### DIFF
--- a/src/modules/AmidoBuild/command/Stop-Task.ps1
+++ b/src/modules/AmidoBuild/command/Stop-Task.ps1
@@ -21,7 +21,7 @@ function Stop-Task() {
 
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory=$false)]
         [string]
         # Error message to be displayed
         $Message,

--- a/src/modules/AmidoBuild/exported/Invoke-YamlLint.ps1
+++ b/src/modules/AmidoBuild/exported/Invoke-YamlLint.ps1
@@ -42,7 +42,12 @@ function Invoke-YamlLint() {
         [Alias("b")]
         [string]
         # Base path to search
-        $BasePath = (Get-Location)
+        $BasePath = (Get-Location),
+
+        [Alias("c")]
+        [bool]
+        # If true will enable yamllint strict mode
+        $FailOnWarnings = $True
     )
 
     # Check that arguments have been supplied
@@ -66,6 +71,15 @@ function Invoke-YamlLint() {
     if (!(Test-Path -Path $BasePath)) {
         Write-Error -Message ("Specified base path does not exist: {0}" -f $BasePath)
         return
+    }
+
+    # strict mode is enabled with the -s (or --strict) option, the return code will be:
+        # • 0 if no errors or warnings occur
+        # • 1 if one or more errors occur
+        # • 2 if no errors occur, but one or more warnings occur
+    $StrictOption = ""
+    if ($FailOnWarnings -eq $True ) {
+        $StrictOption = "-s"
     }
 
     # Find the path to python
@@ -107,7 +121,7 @@ function Invoke-YamlLint() {
     }
 
     # Create the command that needs to be run to perform the lint function
-    $cmd = "{0} -m yamllint -sc {1} {2} {1}" -f $python, $ConfigFile, $BasePath
+    $cmd = "{0} -m yamllint {3} -c {1} {2} {1}" -f $python, $ConfigFile, $BasePath, $StrictOption
     Invoke-External -Command $cmd
 
 }


### PR DESCRIPTION
# Pull Request Template

## 📲 What

Exit codes are now returned correctly and are not hidden

Expose **yamllint** strict mode so it can be set by the calling pipeline

## 🤔 Why

Exit codes were being hidden. This meant the pipelines were successful even though there were errors in taskctl.

## 🛠 How

- Updated Stop-Task().ps1 so it isn't mandatory
There are a few places where this function is being called and we are not providing a message. e.g. InvokeExternal.ps1. 
![image](https://github.com/Ensono/independent-runner/assets/47520690/93c6674b-6e9f-4def-9f2b-cf02132cfe1b)
This then hides the actual exit code of the command being run.

- Added FailOnWarnings param to Invoke-YamlLint function
Currently the yamllint is in strict mode "-s" and this should be configurable.
This will mean that our pipeline steps wont fail if they find a lint warning.

## 👀 Evidence

First we run `Invoke-YamlLint ` and it finds a warning and the exit code is "False" which is correct.
Second time we run `Invoke-YamlLint -FailOnWarnings $False` and its finds a warning but this time the exit code is "True".
![image](https://github.com/Ensono/independent-runner/assets/47520690/865a8cd0-07d1-45e4-bdab-aa10d11bab14)
