### PR TITLE
feat: Adds `-Repo` command to Helm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ outputs
 envfile
 .DS_Store
 docs/reference
+
+# Used to store Pester exit code to detect failure
+.PesterErrorCode

--- a/build/azuredevops-runner.yml
+++ b/build/azuredevops-runner.yml
@@ -27,7 +27,7 @@ stages:
             targetType: inline
             script: |
               wget https://github.com/taskctl/taskctl/releases/download/${{ variables.TaskctlVersion }}/taskctl_${{ variables.TaskctlVersion }}_linux_amd64.tar.gz -O /tmp/taskctl.tar.gz
-              tar zxf /tmp/taskctl.tar.gz -C /usr/local/bin taskctl 
+              tar zxf /tmp/taskctl.tar.gz -C /usr/local/bin taskctl
 
         # Install Stacks Envfile to generate the envfile to be used by docker
         - task: Bash@3
@@ -52,8 +52,7 @@ stages:
           inputs:
             targetType: inline
             script: |
-              taskctl tests:unit
-              taskctl tests:coverage_report
+              taskctl tests
 
         # Run the task to generate the PowerShell module files
         - task: Bash@3
@@ -100,7 +99,7 @@ stages:
   - stage: Release
 
     jobs:
-    
+
     - job: Publish
       steps:
         - checkout: self # Local use of Powershell Modules
@@ -125,7 +124,7 @@ stages:
             targetType: inline
             script: |
               wget https://github.com/taskctl/taskctl/releases/download/${{ variables.TaskctlVersion }}/taskctl_${{ variables.TaskctlVersion }}_linux_amd64.tar.gz -O /tmp/taskctl.tar.gz
-              tar zxf /tmp/taskctl.tar.gz -C /usr/local/bin taskctl 
+              tar zxf /tmp/taskctl.tar.gz -C /usr/local/bin taskctl
 
         # Install Stacks Envfile to generate the envfile to be used by docker
         - task: Bash@3
@@ -144,9 +143,8 @@ stages:
             script: |
               taskctl release
           ${{ if eq(variables['Build.SourceBranch'], 'refs/heads/main') }}: # On main branch runs
-            env: 
+            env:
               STAGE: release
               PUBLISH_RELEASE: "true"
               DASHBOARD_INFLUX_TOKEN: $(DASHBOARD_INFLUX_TOKEN) # requires explicit mapping to be used as an env var
               VERSION_NUMBER: $(BUILD_BUILDNUMBER)
-

--- a/build/azuredevops-runner.yml
+++ b/build/azuredevops-runner.yml
@@ -70,6 +70,14 @@ stages:
             script: |
               taskctl docs
 
+        # Munges the file paths by replacing the bound `/app` directory with the $(Build.SourcesDirectory) variable where the files are
+        - task: Bash@3
+          displayName: Updates paths to files outside of TaskCTL Docker Contexts on the Host
+          inputs:
+            targetType: inline
+            script: |
+              sed -i 's%/app/src/%$(Build.SourcesDirectory)/src/%' $(Build.SourcesDirectory)/outputs/tests/Cobertura.xml
+
         # Upload tests and the coverage results
         - task: PublishTestResults@2
           inputs:

--- a/build/azuredevops-runner.yml
+++ b/build/azuredevops-runner.yml
@@ -2,6 +2,14 @@
 # Set the build name which will define the Build Number
 name: 0.0$(Rev:.r)
 
+pr:
+  - main
+
+trigger:
+  branches:
+    include:
+      - 'main'
+
 # Set the agent pool that stages should be run in
 pool:
   vmImage: ubuntu-20.04

--- a/build/azuredevops-runner.yml
+++ b/build/azuredevops-runner.yml
@@ -84,7 +84,7 @@ stages:
           inputs:
             targetType: inline
             script: |
-              sed -i 's%/app/src/%$(Build.SourcesDirectory)/src/%' $(Build.SourcesDirectory)/outputs/tests/Cobertura.xml
+              sudo sed -i 's%/app/src/%$(Build.SourcesDirectory)/src/%' $(Build.SourcesDirectory)/outputs/tests/Cobertura.xml
 
         # Upload tests and the coverage results
         - task: PublishTestResults@2

--- a/build/azuredevops-runner.yml
+++ b/build/azuredevops-runner.yml
@@ -80,6 +80,7 @@ stages:
 
         # Munges the file paths by replacing the bound `/app` directory with the $(Build.SourcesDirectory) variable where the files are
         - task: Bash@3
+          condition: always()
           displayName: Updates paths to files outside of TaskCTL Docker Contexts on the Host
           inputs:
             targetType: inline
@@ -88,12 +89,14 @@ stages:
 
         # Upload tests and the coverage results
         - task: PublishTestResults@2
+          condition: always()
           inputs:
             testResultsFormat: NUnit
             testResultsFiles: '**/pester-unittest-results.xml'
             testRunTitle: UnitTests
 
         - task: PublishCodeCoverageResults@1
+          condition: always()
           inputs:
             codeCoverageTool: 'Cobertura'
             summaryFileLocation: $(Build.SourcesDirectory)/outputs/tests/Cobertura.xml

--- a/build/scripts/Test-PesterExitCode.ps1
+++ b/build/scripts/Test-PesterExitCode.ps1
@@ -1,0 +1,14 @@
+
+[CmdletBinding()]
+param (
+)
+
+$pesterErrorCodePath = "./test"
+$pesterErrorCodeFile = ".PesterErrorCode"
+$pesterErrorCodeFilePath = "${pesterErrorCodePath}/${pesterErrorCodeFile}"
+
+if (Test-Path -Path $pesterErrorCodeFilePath -PathType leaf) {
+    Write-Error "ERROR: Test Failures, exiting non-zero to fail the build..."
+    $exitCode = Get-Content -Path $pesterErrorCodeFilePath
+    exit $exitCode
+}

--- a/build/taskctl/contexts.yaml
+++ b/build/taskctl/contexts.yaml
@@ -32,7 +32,7 @@ contexts:
         - PSModulePath=/app/src/modules
         - -w
         - /app
-        - amidostacks/runner-pwsh:0.3.141-unstable
+        - amidostacks/runner-pwsh:0.4.20-stable
         - pwsh
         - -NoProfile
         - -Command
@@ -53,7 +53,7 @@ contexts:
         - PSModulePath=/app/src/modules
         - -w
         - /app
-        - amidostacks/runner-pwsh:0.3.141-unstable
+        - amidostacks/runner-pwsh:0.4.20-stable
         - pwsh
         - -NoProfile
         - -Command
@@ -75,7 +75,7 @@ contexts:
         - PSModulePath=/app/src/modules
         - -w
         - /app
-        - amidostacks/runner-pwsh:0.3.141-unstable
+        - amidostacks/runner-pwsh:0.4.20-stable
         - pwsh
         - -NoProfile
         - -Command
@@ -96,7 +96,7 @@ contexts:
         - PSModulePath=/app/src/modules
         - -w
         - /app
-        - amidostacks/runner-pwsh-dotnet:0.3.141-unstable
+        - amidostacks/runner-pwsh-dotnet:0.4.20-stable
         - pwsh
         - -NoProfile
         - -Command

--- a/build/taskctl/contexts.yaml
+++ b/build/taskctl/contexts.yaml
@@ -9,7 +9,7 @@ contexts:
         - -v
         - ${PWD}:/app
         - -e
-        - PSModulePath=/app/src/modules        
+        - PSModulePath=/app/src/modules
         - -w
         - /app
         - russellseymour/pandoc-asciidoctor
@@ -100,4 +100,4 @@ contexts:
         - pwsh
         - -NoProfile
         - -Command
-    quote: "'"    
+    quote: "'"

--- a/build/taskctl/tasks.yaml
+++ b/build/taskctl/tasks.yaml
@@ -31,6 +31,12 @@ tasks:
     command:
       - Invoke-DotNet -Coverage -Pattern pester-coverage.xml -Path /app -Source /app/src/modules/AmidoBuild -Target /app/outputs/tests
 
+  tests:fail_on_error:
+    context: powershell_test
+    description: A task that fails if the `.PesterErrorCode` is present from `Invoke-PesterTests.ps1`
+    command:
+      - /app/build/scripts/Test-PesterExitCode.ps1
+
   update:dashboard:
     context: powershell
     description: Update the Deployment Dashboard

--- a/src/modules/AmidoBuild/exported/Invoke-Inspec.Tests.ps1
+++ b/src/modules/AmidoBuild/exported/Invoke-Inspec.Tests.ps1
@@ -28,9 +28,15 @@ Describe "Invoke-Inspec" {
             dryrun = $true
         }
 
+        function inspec() {}
+
         # Mock commands to check that they are being called
         # - Write-Error
         Mock -CommandName Write-Error -MockWith { }
+
+        Mock -CommandName Find-Command -MockWith {
+            return 'inspec'
+        }
 
         Mock -CommandName inspec -MockWith { }
     }

--- a/src/modules/AmidoBuild/exported/Invoke-Inspec.ps1
+++ b/src/modules/AmidoBuild/exported/Invoke-Inspec.ps1
@@ -2,7 +2,7 @@
 function Invoke-Inspec() {
 
     <#
-    
+
     .SYNOPSIS
     Performs infrastructure tests against resources using Inspec
 
@@ -27,10 +27,10 @@ function Invoke-Inspec() {
 
     The `exec` switch is used to perform the tests against the deployed infrastructure.
 
-    When the tests are run they are generated using the JUnit format so that they can be 
+    When the tests are run they are generated using the JUnit format so that they can be
     uploaded to the CI/CD system as test results.
 
-    Authentication for the Azure provider is achieved by setting the necessary values in the 
+    Authentication for the Azure provider is achieved by setting the necessary values in the
     CLIENT_ID, CLIENT_SECRET, TENANT_ID, and SUBSCRIPTION_ID environment variables.
 
     For AWS the authentication environment variables to be set are AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY,
@@ -40,7 +40,7 @@ function Invoke-Inspec() {
     Invoke-Inspec -exec -path . -cloud azure
 
     This will run the tests from the current directory and target the Azure provider.
-    
+
     #>
 
     [CmdletBinding()]
@@ -80,7 +80,7 @@ function Invoke-Inspec() {
             ParameterSetName = "vendor"
         )]
         [switch]
-        $vendor,        
+        $vendor,
 
         [Alias("args")]
         [string[]]

--- a/src/modules/AmidoBuild/exported/Invoke-Terraform.ps1
+++ b/src/modules/AmidoBuild/exported/Invoke-Terraform.ps1
@@ -3,7 +3,7 @@ function Invoke-Terraform() {
 
 
     <#
-    
+
     .SYNOPSIS
     A wrapper for the Terraform command which will invoke the different commands of
     Terraform as required
@@ -15,7 +15,7 @@ function Invoke-Terraform() {
     It is a wrapper for the Terraform command and will generate the necessary command from the inputs that the
     cmdlet is given. The benefit of this cmdlet is that it reduces complexity as people do not need to know how
     to build up the Terraform command each time.
-    
+
     .EXAMPLE
     Invoke-Terraform -init -arguments "false"
 
@@ -23,7 +23,7 @@ function Invoke-Terraform() {
 
     .EXAMPLE
     Invoke-Terraform -plan properties "-input=false", "-out=tf.plan"
-    
+
     Plan the Terraform deployment using the files in the current directory. The properties that have been passed
     are appended directly to the end of the Terraform command. In this example no missing inputs are requests and
     the plan is written out to the `tf.plan` file.
@@ -299,13 +299,13 @@ function Invoke-Terraform() {
         "workspace" {
 
             if ([String]::IsNullOrEmpty($arguments)) {
-                Write-Warning -Message "No workspace name specified to create or switch to."
+                Write-Error -Message "No workspace name specified to create or switch to."
             } else {
                 Write-Information -MessageData ("Attempting to select or create workspace: {0}" -f $arguments[0])
-                $command = "{0} workspace select -or-create=true {1} " -f $terraform, $arguments[0]
-                    Invoke-External -Command $command
-                }
+                $command = "{0} workspace select -or-create=true {1}" -f $terraform, $arguments[0]
+                Invoke-External -Command $command
             }
+        }
 
     }
 

--- a/src/modules/AmidoBuild/exported/Invoke-YamlLint.Tests.ps1
+++ b/src/modules/AmidoBuild/exported/Invoke-YamlLint.Tests.ps1
@@ -25,7 +25,7 @@ Describe "Invoke-YamlLint" {
         Mock -CommandName Write-Information -MockWith { }
 
         # - Find-Command - return the name of the command that is required
-        # Mock -Command Find-Command -MockWith { return $name }        
+        # Mock -Command Find-Command -MockWith { return $name }
     }
 
     Context "config file does not exist" {
@@ -94,7 +94,7 @@ Describe "Invoke-YamlLint" {
             # Ensure yamllint is being installed
             $session.commands.list[1] | Should -BeLike ("*pip* install yamllint")
 
-            $session.commands.list[2] | Should -BeLike ("*python* -m yamllint -sc {0} {1} {0}" -f $configFile.Fullname, $testFolder)
+            $session.commands.list[2] | Should -BeLike ("*python* -m yamllint -s -c {0} {1} {0}" -f $configFile.Fullname, $testFolder)
 
             Should -Invoke -CommandName Write-Information -Times 1
         }

--- a/taskctl.yaml
+++ b/taskctl.yaml
@@ -9,9 +9,13 @@ pipelines:
 
   tests:
     - task: tests:unit
+      allow_failure: true
     - task: tests:coverage_report
       depends_on:
         - tests:unit
+    - task: tests:fail_on_error
+      depends_on:
+        - tests:coverage_report
 
   build:
     - task: setup:environment


### PR DESCRIPTION
fix: Fixes build false passing by handling errors
 * Gracefully handles Pester errors by storing the exit code in a file, running the next code coverage task, and then finally running a task which will exit based on the exit code in the file. This should make the build fail now, while still running the HTML Code Coverage generation task.
 * Fixes the YAMLLint test, leaving TF deliberately failing to see if the build now fails as expected.
 * Ensures the build runs the root `tests` task and not the individual
   ones.

feat: Adds `repo` command to Helm
 * Adds a `-Repo` command for adding repos to Helm, this means it's no
   longer required to use a custom command
 * The new `-Repo` command doesn't log into a Cloud Provider
   whereas `-Custom` still does (to maintian bc)
 * Fixes the Helm tests which weren't working properly (although more
   tests should be added in future as currently there aren't exhaustive
   tests there)
 * Fixes the Terraform Tests since the change to workspace command
 * Moves not supplying a workspace to select to an Error, from Warning

fix: Fix 'missing' files by using sed
 * Fix the error 'File '/app/src/*' does not exist (any more).' by using
   sed to replace the TaskCTL Docker context bind path with the path to
   the files on the host agent.

NOTE: More Helm tests should be added in future to exhaustively test it