### PR TITLE
Provide realtime feedback of Invoke-External commands

### DIFF
--- a/src/modules/AmidoBuild/command/Invoke-External.ps1
+++ b/src/modules/AmidoBuild/command/Invoke-External.ps1
@@ -58,7 +58,9 @@ function Invoke-External {
             # Reset the LASTEXITCODE as it can be tripped from a variety of places...
             $global:LASTEXITCODE = 0
 
-            Invoke-Expression -Command $command
+            Invoke-Expression -Command $command | Tee-Object -variable output
+            
+            Write-Output -InputObject $output
 
             # Add the exit code to the session, if it exists
             if (Get-Variable -Name Session -Scope global -ErrorAction SilentlyContinue) {

--- a/src/modules/AmidoBuild/command/Invoke-External.ps1
+++ b/src/modules/AmidoBuild/command/Invoke-External.ps1
@@ -58,9 +58,7 @@ function Invoke-External {
             # Reset the LASTEXITCODE as it can be tripped from a variety of places...
             $global:LASTEXITCODE = 0
 
-            $output = Invoke-Expression -Command $command
-
-            Write-Output -InputObject $output
+            Invoke-Expression -Command $command
 
             # Add the exit code to the session, if it exists
             if (Get-Variable -Name Session -Scope global -ErrorAction SilentlyContinue) {


### PR DESCRIPTION
# Pull Request Template

## 📲 What

Provide realtime feedback of Invoke-External commands

## 🤔 Why

Without this you have to wait until the command has finished before you see the output.
Now when running a command e.g. terraform apply, you can see the progress. 

## 🛠 How

Removed the code that puts the output of Invoke-External into a variable

## 👀 Evidence

