### PR TITLE
fix: Changes base path for yamllint to `.`

### DIFF
--- a/src/modules/AmidoBuild/exported/Invoke-YamlLint.ps1
+++ b/src/modules/AmidoBuild/exported/Invoke-YamlLint.ps1
@@ -42,7 +42,7 @@ function Invoke-YamlLint() {
         [Alias("b")]
         [string]
         # Base path to search
-        $BasePath = (Get-Location),
+        $BasePath = ".",
 
         [Alias("c")]
         [bool]


### PR DESCRIPTION
In order for YAMLLint ignore paths to work, pass in `.` as the default path instead of `(Get-Location)`.