### PR TITLE
Update module cmdlet to correctly create Docker Image

### DIFF
--- a/src/modules/EnsonoBuild/exported/Build-DockerImage.Tests.ps1
+++ b/src/modules/EnsonoBuild/exported/Build-DockerImage.Tests.ps1
@@ -132,7 +132,7 @@ Describe "Build-DockerImage" -Skip:($skipDockerTests -eq 1) {
             # Call the function under test
             Build-DockerImage -name pester-tests -tag "unittests"
 
-            $Session.commands.list[0] | Should -BeLike "*docker* buildx build . -t pester-tests:unittests --platform linux/amd64"
+            $Session.commands.list[0] | Should -BeLike "*docker* buildx build . -t docker.io/pester-tests:unittests --platform linux/amd64"
         }
 
         AfterAll {
@@ -150,7 +150,7 @@ Describe "Build-DockerImage" -Skip:($skipDockerTests -eq 1) {
             # Call the function under test
             Build-DockerImage -name pester-tests -tag "unittests"
 
-            $Session.commands.list[0] | Should -BeLike "*docker* buildx build . -t pester-tests:unittests --platform linux/arm64"
+            $Session.commands.list[0] | Should -BeLike "*docker* buildx build . -t docker.io/pester-tests:unittests --platform linux/arm64"
         }
 
         AfterAll {
@@ -172,7 +172,7 @@ Describe "Build-DockerImage" -Skip:($skipDockerTests -eq 1) {
 
             # Check that the command that will be run is correct
             # This is done by checking the command list
-            $Session.commands.list[0] | Should -BeLike "*docker* buildx build . -t pester-tests:unittests --platform linux/arm64,linux/amd64"
+            $Session.commands.list[0] | Should -BeLike "*docker* buildx build . -t docker.io/pester-tests:unittests --platform linux/arm64,linux/amd64"
         }
 
         It "will build the image and set a different platform to build for" {
@@ -182,7 +182,7 @@ Describe "Build-DockerImage" -Skip:($skipDockerTests -eq 1) {
 
             # Check that the command that will be run is correct
             # This is done by checking the command list
-            $Session.commands.list[0] | Should -BeLike "*docker* buildx build . -t pester-tests:unittests --platform linux/arm/v7"
+            $Session.commands.list[0] | Should -BeLike "*docker* buildx build . -t docker.io/pester-tests:unittests --platform linux/arm/v7"
         }
 
         It "will tag the image accordingly if a registry is specified" {
@@ -190,7 +190,7 @@ Describe "Build-DockerImage" -Skip:($skipDockerTests -eq 1) {
             # Call the function under test
             Build-DockerImage -name pester-tests -tag "unittests" -Registry "pesterreg" -platforms "linux/arm64","linux/amd64"
 
-            $Session.commands.list[0] | Should -BeLike "*docker* buildx build . -t pester-tests:unittests -t pesterreg/pester-tests:unittests --platform linux/arm64,linux/amd64"
+            $Session.commands.list[0] | Should -BeLike "*docker* buildx build . -t pesterreg/pester-tests:unittests --platform linux/arm64,linux/amd64"
         }
 
         It "will correctly change the case of the input to create a valid image" {
@@ -198,7 +198,7 @@ Describe "Build-DockerImage" -Skip:($skipDockerTests -eq 1) {
             # Call the function under test
             Build-DockerImage -name Pester-tests -tag "Unittests" -Registry "pesterreg" -platforms "linux/arm64","linux/amd64"
 
-            $Session.commands.list[0] | Should -BeLikeExactly "*docker* buildx build . -t pester-tests:unittests -t pesterreg/pester-tests:unittests --platform linux/arm64,linux/amd64"
+            $Session.commands.list[0] | Should -BeLikeExactly "*docker* buildx build . -t pesterreg/pester-tests:unittests --platform linux/arm64,linux/amd64"
 
         }
 
@@ -209,7 +209,7 @@ Describe "Build-DockerImage" -Skip:($skipDockerTests -eq 1) {
             # Call the function under test
             Build-DockerImage -name Pester-tests -tag "Unittests" -Registry "pesterreg" -latest -force -platforms "linux/arm64","linux/amd64"
 
-            $Session.commands.list[0] | Should -BeLikeExactly "*docker* buildx build . -t pester-tests:unittests -t pesterreg/pester-tests:unittests -t pesterreg/pester-tests:latest --platform linux/arm64,linux/amd64"
+            $Session.commands.list[0] | Should -BeLikeExactly "*docker* buildx build . -t pesterreg/pester-tests:unittests -t pesterreg/pester-tests:latest --platform linux/arm64,linux/amd64"
         }
 
         It "will remove quotes surrounding build args when passing to Docker" {
@@ -217,7 +217,7 @@ Describe "Build-DockerImage" -Skip:($skipDockerTests -eq 1) {
             # Call the function to test
             Build-DockerImage -name Pester-tests -tag "Unittests" -Registry "pesterreg" -BuildArgs "`"--build-arg functionName=PesterFunction .`"" -platforms "linux/arm64","linux/amd64"
 
-            $Session.commands.list[0] | Should -BeLikeExactly "*docker* buildx build --build-arg functionName=PesterFunction . -t pester-tests:unittests -t pesterreg/pester-tests:unittests --platform linux/arm64,linux/amd64"
+            $Session.commands.list[0] | Should -BeLikeExactly "*docker* buildx build --build-arg functionName=PesterFunction . -t pesterreg/pester-tests:unittests --platform linux/arm64,linux/amd64"
         }
 
     }
@@ -229,7 +229,7 @@ Describe "Build-DockerImage" -Skip:($skipDockerTests -eq 1) {
             # Call the function under test
             Build-DockerImage -name Pester-tests -tag "Unittests" -Registry "pesterreg" -latest -platforms "linux/arm64","linux/amd64"
 
-            $Session.commands.list[0] | Should -BeLikeExactly "*docker* buildx build . -t pester-tests:unittests -t pesterreg/pester-tests:unittests -t pesterreg/pester-tests:latest --platform linux/arm64,linux/amd64"
+            $Session.commands.list[0] | Should -BeLikeExactly "*docker* buildx build . -t pesterreg/pester-tests:unittests -t pesterreg/pester-tests:latest --platform linux/arm64,linux/amd64"
         }
 
         it "will not set latest if not on a trunk branch" {
@@ -239,7 +239,7 @@ Describe "Build-DockerImage" -Skip:($skipDockerTests -eq 1) {
              # Call the function under test
              Build-DockerImage -name Pester-tests -tag "Unittests" -Registry "pesterreg" -latest -platforms "linux/arm64","linux/amd64"
 
-             $Session.commands.list[0] | Should -BeLikeExactly "*docker* buildx build . -t pester-tests:unittests -t pesterreg/pester-tests:unittests --platform linux/arm64,linux/amd64"
+             $Session.commands.list[0] | Should -BeLikeExactly "*docker* buildx build . -t pesterreg/pester-tests:unittests --platform linux/arm64,linux/amd64"
         }
     }
 
@@ -269,7 +269,7 @@ Describe "Build-DockerImage" -Skip:($skipDockerTests -eq 1) {
             $Session.commands.list[0] | Should -BeLike "*docker* login docker.io -u pester -p pester123" 
 
             # Check the build command
-            $Session.commands.list[1] | Should -BeLike "*docker* buildx build . -t pester-tests:unittests -t docker.io/pester-tests:unittests --platform linux/amd64 --push"
+            $Session.commands.list[1] | Should -BeLike "*docker* buildx build . -t docker.io/pester-tests:unittests --platform linux/amd64 --push"
 
         }
 
@@ -291,7 +291,7 @@ Describe "Build-DockerImage" -Skip:($skipDockerTests -eq 1) {
             $Session.commands.list.length | Should -Be 1
 
             # Check the build command
-            $Session.commands.list[0] | Should -BeLike "*docker* buildx build . -t pester-tests:unittests -t docker.io/pester-tests:unittests --platform linux/arm64,linux/amd64"
+            $Session.commands.list[0] | Should -BeLike "*docker* buildx build . -t docker.io/pester-tests:unittests --platform linux/arm64,linux/amd64"
 
             # Remove the environment variable
             if ($no_push_exists) {
@@ -336,7 +336,7 @@ Describe "Build-DockerImage" -Skip:($skipDockerTests -eq 1) {
             $Session.commands.list[0] | Should -BeLike "*docker* login docker.io -u pester -p pester123"
 
             # Check the build command
-            $Session.commands.list[1] | Should -BeLike "*docker* buildx build . -t pester-tests:unittests -t docker.io/pester-tests:unittests -t docker.io/pester-tests:latest --platform linux/arm64,linux/amd64 --push"
+            $Session.commands.list[1] | Should -BeLike "*docker* buildx build . -t docker.io/pester-tests:unittests -t docker.io/pester-tests:latest --platform linux/arm64,linux/amd64 --push"
         }
 
         AfterEach {
@@ -364,7 +364,7 @@ Describe "Build-DockerImage" -Skip:($skipDockerTests -eq 1) {
             $Session.commands.list[0] | Should -BeLike "*docker* login docker.io -u pester -p pester123"
 
             # Check the build command
-            $Session.commands.list[1] | Should -BeLike "*docker* buildx build . -t pester-tests:unittests -t docker.io/pester-tests:unittests --platform linux/arm64,linux/amd64 --push"
+            $Session.commands.list[1] | Should -BeLike "*docker* buildx build . -t docker.io/pester-tests:unittests --platform linux/arm64,linux/amd64 --push"
 
         }
     }
@@ -387,7 +387,7 @@ Describe "Build-DockerImage" -Skip:($skipDockerTests -eq 1) {
             $Session.commands.list[0] | Should -BeLike "*docker* login docker.io -u pester -p pester123"
 
             # Check the build command
-            $Session.commands.list[1] | Should -BeLike "*docker* buildx build . -t pester-tests:unittests -t docker.io/pester-tests:unittests -t docker.io/pester-tests:latest --platform linux/arm64,linux/amd64 --push"
+            $Session.commands.list[1] | Should -BeLike "*docker* buildx build . -t docker.io/pester-tests:unittests -t docker.io/pester-tests:latest --platform linux/arm64,linux/amd64 --push"
         }
     }
 }

--- a/src/modules/EnsonoBuild/exported/Build-DockerImage.Tests.ps1
+++ b/src/modules/EnsonoBuild/exported/Build-DockerImage.Tests.ps1
@@ -132,7 +132,7 @@ Describe "Build-DockerImage" -Skip:($skipDockerTests -eq 1) {
             # Call the function under test
             Build-DockerImage -name pester-tests -tag "unittests"
 
-            $Session.commands.list[0] | Should -BeLike "*docker* buildx build . -t docker.io/pester-tests:unittests --platform linux/amd64"
+            $Session.commands.list[0] | Should -BeLike "*docker* buildx build -t docker.io/pester-tests:unittests --platform linux/amd64 ."
         }
 
         AfterAll {
@@ -150,7 +150,7 @@ Describe "Build-DockerImage" -Skip:($skipDockerTests -eq 1) {
             # Call the function under test
             Build-DockerImage -name pester-tests -tag "unittests"
 
-            $Session.commands.list[0] | Should -BeLike "*docker* buildx build . -t docker.io/pester-tests:unittests --platform linux/arm64"
+            $Session.commands.list[0] | Should -BeLike "*docker* buildx build -t docker.io/pester-tests:unittests --platform linux/arm64 ."
         }
 
         AfterAll {
@@ -172,7 +172,7 @@ Describe "Build-DockerImage" -Skip:($skipDockerTests -eq 1) {
 
             # Check that the command that will be run is correct
             # This is done by checking the command list
-            $Session.commands.list[0] | Should -BeLike "*docker* buildx build . -t docker.io/pester-tests:unittests --platform linux/arm64,linux/amd64"
+            $Session.commands.list[0] | Should -BeLike "*docker* buildx build -t docker.io/pester-tests:unittests --platform linux/arm64,linux/amd64 ."
         }
 
         It "will build the image and set a different platform to build for" {
@@ -182,7 +182,7 @@ Describe "Build-DockerImage" -Skip:($skipDockerTests -eq 1) {
 
             # Check that the command that will be run is correct
             # This is done by checking the command list
-            $Session.commands.list[0] | Should -BeLike "*docker* buildx build . -t docker.io/pester-tests:unittests --platform linux/arm/v7"
+            $Session.commands.list[0] | Should -BeLike "*docker* buildx build -t docker.io/pester-tests:unittests --platform linux/arm/v7 ."
         }
 
         It "will tag the image accordingly if a registry is specified" {
@@ -190,7 +190,7 @@ Describe "Build-DockerImage" -Skip:($skipDockerTests -eq 1) {
             # Call the function under test
             Build-DockerImage -name pester-tests -tag "unittests" -Registry "pesterreg" -platforms "linux/arm64","linux/amd64"
 
-            $Session.commands.list[0] | Should -BeLike "*docker* buildx build . -t pesterreg/pester-tests:unittests --platform linux/arm64,linux/amd64"
+            $Session.commands.list[0] | Should -BeLike "*docker* buildx build -t pesterreg/pester-tests:unittests --platform linux/arm64,linux/amd64 ."
         }
 
         It "will correctly change the case of the input to create a valid image" {
@@ -198,7 +198,7 @@ Describe "Build-DockerImage" -Skip:($skipDockerTests -eq 1) {
             # Call the function under test
             Build-DockerImage -name Pester-tests -tag "Unittests" -Registry "pesterreg" -platforms "linux/arm64","linux/amd64"
 
-            $Session.commands.list[0] | Should -BeLikeExactly "*docker* buildx build . -t pesterreg/pester-tests:unittests --platform linux/arm64,linux/amd64"
+            $Session.commands.list[0] | Should -BeLikeExactly "*docker* buildx build -t pesterreg/pester-tests:unittests --platform linux/arm64,linux/amd64 ."
 
         }
 
@@ -209,15 +209,15 @@ Describe "Build-DockerImage" -Skip:($skipDockerTests -eq 1) {
             # Call the function under test
             Build-DockerImage -name Pester-tests -tag "Unittests" -Registry "pesterreg" -latest -force -platforms "linux/arm64","linux/amd64"
 
-            $Session.commands.list[0] | Should -BeLikeExactly "*docker* buildx build . -t pesterreg/pester-tests:unittests -t pesterreg/pester-tests:latest --platform linux/arm64,linux/amd64"
+            $Session.commands.list[0] | Should -BeLikeExactly "*docker* buildx build -t pesterreg/pester-tests:unittests -t pesterreg/pester-tests:latest --platform linux/arm64,linux/amd64 ."
         }
 
         It "will remove quotes surrounding build args when passing to Docker" {
 
             # Call the function to test
-            Build-DockerImage -name Pester-tests -tag "Unittests" -Registry "pesterreg" -BuildArgs "`"--build-arg functionName=PesterFunction .`"" -platforms "linux/arm64","linux/amd64"
+            Build-DockerImage -name Pester-tests -tag "Unittests" -Registry "pesterreg" -BuildArgs "`"--build-arg functionName=PesterFunction`"" -BuildPath "." -platforms "linux/arm64","linux/amd64"
 
-            $Session.commands.list[0] | Should -BeLikeExactly "*docker* buildx build --build-arg functionName=PesterFunction . -t pesterreg/pester-tests:unittests --platform linux/arm64,linux/amd64"
+            $Session.commands.list[0] | Should -BeLikeExactly "*docker* buildx build --build-arg functionName=PesterFunction -t pesterreg/pester-tests:unittests --platform linux/arm64,linux/amd64 ."
         }
 
     }
@@ -229,7 +229,7 @@ Describe "Build-DockerImage" -Skip:($skipDockerTests -eq 1) {
             # Call the function under test
             Build-DockerImage -name Pester-tests -tag "Unittests" -Registry "pesterreg" -latest -platforms "linux/arm64","linux/amd64"
 
-            $Session.commands.list[0] | Should -BeLikeExactly "*docker* buildx build . -t pesterreg/pester-tests:unittests -t pesterreg/pester-tests:latest --platform linux/arm64,linux/amd64"
+            $Session.commands.list[0] | Should -BeLikeExactly "*docker* buildx build -t pesterreg/pester-tests:unittests -t pesterreg/pester-tests:latest --platform linux/arm64,linux/amd64 ."
         }
 
         it "will not set latest if not on a trunk branch" {
@@ -239,7 +239,7 @@ Describe "Build-DockerImage" -Skip:($skipDockerTests -eq 1) {
              # Call the function under test
              Build-DockerImage -name Pester-tests -tag "Unittests" -Registry "pesterreg" -latest -platforms "linux/arm64","linux/amd64"
 
-             $Session.commands.list[0] | Should -BeLikeExactly "*docker* buildx build . -t pesterreg/pester-tests:unittests --platform linux/arm64,linux/amd64"
+             $Session.commands.list[0] | Should -BeLikeExactly "*docker* buildx build -t pesterreg/pester-tests:unittests --platform linux/arm64,linux/amd64 ."
         }
     }
 
@@ -269,7 +269,7 @@ Describe "Build-DockerImage" -Skip:($skipDockerTests -eq 1) {
             $Session.commands.list[0] | Should -BeLike "*docker* login docker.io -u pester -p pester123" 
 
             # Check the build command
-            $Session.commands.list[1] | Should -BeLike "*docker* buildx build . -t docker.io/pester-tests:unittests --platform linux/amd64 --push"
+            $Session.commands.list[1] | Should -BeLike "*docker* buildx build -t docker.io/pester-tests:unittests --platform linux/amd64 --push ."
 
         }
 
@@ -291,7 +291,7 @@ Describe "Build-DockerImage" -Skip:($skipDockerTests -eq 1) {
             $Session.commands.list.length | Should -Be 1
 
             # Check the build command
-            $Session.commands.list[0] | Should -BeLike "*docker* buildx build . -t docker.io/pester-tests:unittests --platform linux/arm64,linux/amd64"
+            $Session.commands.list[0] | Should -BeLike "*docker* buildx build -t docker.io/pester-tests:unittests --platform linux/arm64,linux/amd64 ."
 
             # Remove the environment variable
             if ($no_push_exists) {
@@ -336,7 +336,7 @@ Describe "Build-DockerImage" -Skip:($skipDockerTests -eq 1) {
             $Session.commands.list[0] | Should -BeLike "*docker* login docker.io -u pester -p pester123"
 
             # Check the build command
-            $Session.commands.list[1] | Should -BeLike "*docker* buildx build . -t docker.io/pester-tests:unittests -t docker.io/pester-tests:latest --platform linux/arm64,linux/amd64 --push"
+            $Session.commands.list[1] | Should -BeLike "*docker* buildx build -t docker.io/pester-tests:unittests -t docker.io/pester-tests:latest --platform linux/arm64,linux/amd64 --push ."
         }
 
         AfterEach {
@@ -364,7 +364,7 @@ Describe "Build-DockerImage" -Skip:($skipDockerTests -eq 1) {
             $Session.commands.list[0] | Should -BeLike "*docker* login docker.io -u pester -p pester123"
 
             # Check the build command
-            $Session.commands.list[1] | Should -BeLike "*docker* buildx build . -t docker.io/pester-tests:unittests --platform linux/arm64,linux/amd64 --push"
+            $Session.commands.list[1] | Should -BeLike "*docker* buildx build -t docker.io/pester-tests:unittests --platform linux/arm64,linux/amd64 --push ."
 
         }
     }
@@ -387,7 +387,7 @@ Describe "Build-DockerImage" -Skip:($skipDockerTests -eq 1) {
             $Session.commands.list[0] | Should -BeLike "*docker* login docker.io -u pester -p pester123"
 
             # Check the build command
-            $Session.commands.list[1] | Should -BeLike "*docker* buildx build . -t docker.io/pester-tests:unittests -t docker.io/pester-tests:latest --platform linux/arm64,linux/amd64 --push"
+            $Session.commands.list[1] | Should -BeLike "*docker* buildx build -t docker.io/pester-tests:unittests -t docker.io/pester-tests:latest --platform linux/arm64,linux/amd64 --push ."
         }
     }
 }

--- a/src/modules/EnsonoBuild/exported/Build-DockerImage.ps1
+++ b/src/modules/EnsonoBuild/exported/Build-DockerImage.ps1
@@ -172,6 +172,13 @@ function Build-DockerImage() {
     $platforms = @("linux/${arch}")
   }
 
+  # If the registry is null, then set to docker.io
+  # This is done so that all the naming of images is performed correctly
+  if ([String]::IsNullOrEmpty($registry)) {
+    Write-Information -MessageData "No registry has been specified, defaulting to docker.io"
+    $registry = "docker.io"
+  }
+
   # If the push switch has been specified then check that a registry
   # has been specified
   if ($push.IsPresent -and ([string]::IsNullOrEmpty($provider) -or ([string]::IsNullOrEmpty($registry) -and !(Test-Path -Path env:\NO_PUSH)))) {
@@ -260,16 +267,13 @@ function Build-DockerImage() {
   # Create an array to store the arguments to pass to docker
   $arguments = @()
   $arguments += $buildArgs.Trim("`"", " ")
-  $arguments += "-t {0}:{1}" -f $name, $tag
 
-  # if the registry name has been set, add t to the tasks
-  if (![String]::IsNullOrEmpty($registry)) {
-    $arguments += "-t {0}/{1}:{2}" -f $registry, $name, $tag
+  $arguments += "-t {0}/{1}:{2}" -f $registry, $name, $tag
 
-    if ($setAsLatest) {
-      $arguments += "-t {0}/{1}:latest" -f $registry, $name
-    }
+  if ($setAsLatest) {
+    $arguments += "-t {0}/{1}:latest" -f $registry, $name
   }
+
 
   # Add in the platforms that need to be built
   $arguments += "--platform {0}" -f ($platforms -join ",")

--- a/src/modules/EnsonoBuild/exported/Build-DockerImage.ps1
+++ b/src/modules/EnsonoBuild/exported/Build-DockerImage.ps1
@@ -38,7 +38,14 @@ function Build-DockerImage() {
     )]
     [string]
     # Arguments for docker build
-    $buildargs = ".",
+    $buildargs,
+
+    [Parameter(
+      ParameterSetName = "build"
+    )]
+    [string]
+    # Path to the build directory
+    $BuildPath = ".",
 
     [Parameter(
       ParameterSetName = "build",
@@ -287,6 +294,9 @@ function Build-DockerImage() {
   if ($build_and_push) {
     $arguments += "--push"
   }
+
+  # Add the buildPath to the end of the arguments
+  $arguments += $BuildPath
 
   # Create the cmd to execute
   $cmd = "docker buildx build {0}" -f ($arguments -Join " ")


### PR DESCRIPTION
## 📲 What

Corrected the `Build-DockerImage` cmdlet so that when a custom registry is specified it does *not* just tag without a registry.

Fixes #45

## 🤔 Why

When a registry was not specified, the new image was tagged without one. So this meant that when the image was pushed using `docker push` it will go to docker.io.

However when a custom registry is specified the image was tagged with the correct custom registry as well as without one. This meant that when the cmdlet tried to push the image it would attempt to push to the custom registry as well as docker.io.

## 🛠 How

This has been fixed as such:

1. When no registry is specified, it is automatically set as `docker.io`. This means that there is no chance the image is named without a registry

2. The default value for the `buildArgs` was `.` which meant that Docker will build from the current directory. However if the `buildArgs` was overridden then this would be lost, meaning the docker build would fail.

A new parameter has been added called `buildPath` that defaults to `.` which is appended to the end of the Docker command.

## 👀 Evidence

All tests are still passing

## 🕵️ How to test

Notes for QA