### PR TITLE
Allow additional Inspec exit codes

### DIFF
--- a/src/modules/EnsonoBuild/command/Invoke-External.ps1
+++ b/src/modules/EnsonoBuild/command/Invoke-External.ps1
@@ -20,8 +20,15 @@ function Invoke-External {
 
         [switch]
         # State if should be run in DryRun mode, e.g. do not execute the command
-        $dryrun
+        $dryrun,
+
+        [Int[]]
+        # Additional exit codes that are acceptable from the command
+        $AdditionalExitCodes = @()
     )
+
+    # Set all of the exit codes that are acceptable
+    $exitCodes = @(0) + $AdditionalExitCodes
 
     foreach ($command in $commands) {
 
@@ -67,7 +74,7 @@ function Invoke-External {
 
 
             # Stop the task if the LASTEXITCODE is greater than 0
-            if ($LASTEXITCODE -gt 0) {
+            if ($LASTEXITCODE -notin $exitCodes) {
                 Stop-Task -ExitCode $LASTEXITCODE
             }
 

--- a/src/modules/EnsonoBuild/exported/Invoke-Inspec.ps1
+++ b/src/modules/EnsonoBuild/exported/Invoke-Inspec.ps1
@@ -89,7 +89,12 @@ function Invoke-Inspec() {
 
         [string]
         # Output path for test report
-        $output = $env:INSPEC_OUTPUT_PATH
+        $output = $env:INSPEC_OUTPUT_PATH,
+
+        [Int[]]
+        # List of exit codes that are accepatable
+        # Zero is always accepted
+        $ExitCodes = @()
 
     )
 
@@ -219,7 +224,7 @@ function Invoke-Inspec() {
 
     # Run the command that has been built up
     if (![string]::IsNullOrEmpty($command)) {
-        Invoke-External -Command $command
+        Invoke-External -Command $command -AdditionalExitCodes $ExitCodes
     }
 
     # Change back to the original dirrectory if changed at the begining

--- a/src/modules/EnsonoBuild/exported/Invoke-Inspec.ps1
+++ b/src/modules/EnsonoBuild/exported/Invoke-Inspec.ps1
@@ -27,6 +27,10 @@ function Invoke-Inspec() {
 
     The `exec` switch is used to perform the tests against the deployed infrastructure.
 
+    Inspec uses different exit codes to denotes when tests have been skipped. For example, in this case
+    the exit code is 1, which will cause `Invoke-External` to stop. To avoid this issue, this cmdlet
+    has an `ExitCodes` parameter that can be used to specify which exit codes are acceptable, in addition to 0.
+
     When the tests are run they are generated using the JUnit format so that they can be
     uploaded to the CI/CD system as test results.
 

--- a/src/modules/EnsonoBuild/exported/Invoke-Inspec.ps1
+++ b/src/modules/EnsonoBuild/exported/Invoke-Inspec.ps1
@@ -45,6 +45,12 @@ function Invoke-Inspec() {
 
     This will run the tests from the current directory and target the Azure provider.
 
+    .EXAMPLE
+    Invoke-Inspec -exec -path . -cloud azure -exitCodes 101
+
+    This will run the tests from the current directory and target the Azure provider. Any skipped tests
+    will result in an exit code of 101, which will now be accepted.
+
     #>
 
     [CmdletBinding()]
@@ -52,7 +58,7 @@ function Invoke-Inspec() {
 
         [string]
         # Path to the inspec test files
-        $path = $env:TESTS_PATH,
+        $path = ($env:INSPEC_FILES ? $env:INSPEC_FILES : $env:TESTS_PATH),
 
         [Parameter(
             ParameterSetName = "init"
@@ -93,7 +99,7 @@ function Invoke-Inspec() {
 
         [string]
         # Output path for test report
-        $output = $env:INSPEC_OUTPUT_PATH,
+        $output = ($env:INSPEC_OUTPUT ? $env:INSPEC_OUTPUT : $env:INSPEC_OUTPUT_PATH),
 
         [Int[]]
         # List of exit codes that are accepatable


### PR DESCRIPTION
## 📲 What

When Inspec has skipped tests (die to a condition for example) the exit code, given that there are no errors, is 101.

## 🤔 Why

This has been added because the `Invoke-External` cmdlet stops the running task on anything that is greater than 0. So in the case of skipped tests the pipeline will fail.

## 🛠 How

I have added a new parameter to the `Invoke-External` cmdlet called `AdditionalExitCodes`. I have also added an `ExitCodes` parameter to `Invoke-Inspec`. Now when `Invoke-Inspec` is called, the allowed exit codes can be specified as well, e.g.:

```
Invoke-Inspec -execute -path . -cloud azure -exitcodes 101
```

NOTE: An exit code of 0 is always accepted and does not need to be specified

The exitcodes that are passed to `Invoke-Inspec` are then passed to the `Invoke-External` cmdlet and checked when the the command has executed.

## 👀 Evidence

The following shows the output of the `Invoke-Inspec` cmdlet when tests are successful but there have been skipped tests:

![image](https://github.com/Ensono/independent-runner/assets/791658/93b18742-4777-4fb1-9eab-07c3922eaf39)


## 🕵️ How to test

Notes for QA