### PR TITLE
Select version of Terraform to use

### DIFF
--- a/src/modules/EnsonoBuild/command/Invoke-External.ps1
+++ b/src/modules/EnsonoBuild/command/Invoke-External.ps1
@@ -72,8 +72,9 @@ function Invoke-External {
                 $global:Session.commands.exitcodes += $LASTEXITCODE
             }
 
-
             # Stop the task if the LASTEXITCODE is greater than 0
+            Write-Host ("Permitted exit codes: {0}" -f ($exitCodes -join ", "))
+            Write-Host ("Exit code: {0}" -f $LASTEXITCODE)
             if ($LASTEXITCODE -notin $exitCodes) {
                 Stop-Task -ExitCode $LASTEXITCODE
             }

--- a/src/modules/EnsonoBuild/exported/Invoke-Terraform.ps1
+++ b/src/modules/EnsonoBuild/exported/Invoke-Terraform.ps1
@@ -121,7 +121,17 @@ function Invoke-Terraform() {
 
         [string]
         # Delimiter to use to split backend config that has been passed as one string
-        $delimiter = ","
+        $delimiter = ",",
+
+        [string]
+        # Version of Terraform to use
+        # This will look for Terraform in the specified prefix
+        # and will not use the Find-Command cmdlet
+        $Version = $env:TF_VERSION,
+
+        [string]
+        # Path to the base directory for Terraform
+        $Prefix
 
     )
 
@@ -157,8 +167,33 @@ function Invoke-Terraform() {
         }
     }
 
+    # Ensure that the prefix path has been set if it is null
+    # This is done so that the path delimiters are correctly added
+    if ([String]::IsNullOrEmpty($Prefix)) {
+
+        # determine the root
+        $root = "/"
+        if (Test-Path -Path env:\SystemDrive) {
+            $root = $env:SystemDrive
+        }
+
+        $Prefix = [IO.Path]::Combine($root, "usr", "local", "terraform")
+    }
+
     # Find the Terraform command to use
-    $terraform = Find-Command -Name "terraform"
+    if ([String]::IsNullOrEmpty($Version)) {
+        $terraform = Find-Command -Name "terraform"
+    } else {
+
+        # A version has been specified so build up the path to the specified 
+        $terraform = [IO.Path]::Combine($Prefix, $Version, "bin", "terraform")
+
+        # Check to see if the versioned Terraform exists
+        if (!(Test-Path -Path $terraform)) {
+            Write-Error -Message ("Specified Terraform version does not exist: {0}" -f $terraform) -ErrorAction Stop
+            return
+        }
+    }
 
     # If a path has been specified and it is a directory
     # change to that path


### PR DESCRIPTION
## 📲 What

The changes to the `Invoke-Terraform` cmdlet allow the version of Terraform to be chosen.

## 🤔 Why

With Terraform versions being released on a regular basis it is hard to keep everything in line. The https://github.com/Ensono/stacks-docker-images now allow multiple versions of Terraform to be installed - https://github.com/Ensono/stacks-docker-images/pull/99.

A symlink is created in the docker image to the version that is going to be used by default. This is added to the PATH in the image. For example:

`/usr/local/terraform/1.5.1/bin -> /usr/local/terraform/bin`

This is very useful to have a quick way to run TF when running in the container interactively, but when using `Invoke-Terraform` we need a way to be able to specify the version.

## 🛠 How

Two new parameters have been added to the cmdlet:

__Prefix__

The prefix path in which to look for the Terraform binary.

Default: /usr/local/terraform

__Version__

The version of Terraform to use.
If this is not set then the cmdlet will attempt to find the command on the PATH.
If set then the cmdlet will look for the version in the specified prefix path.

Default Value: ""

## 👀 Evidence

The Unit tests have been updated to take into the account the versioning.

__Example__

When the command:

```
Invoke-Terraform -init -Backend "key=tfstate,access_key=123456" -Version 1.5.1
```

is run PowerShell will look for the Terraform command in `/usr/local/terraform/1.5.1/bin/terraform`

__Example__

If Terraform is coming from a different location, e.g. if being mounted from the host then the prefix can be updated. IUn which case the command:

```
Invoke-Terraform -init -Backend "key=tfstate,access_key=123456" -Version 1.5.1 -Prefix /mount/terraform
```

PowerShell will now look for the command in `/mount/terraform/1.5.1/bin/terraform`.

Unitests have been written to suppport this.

https://github.com/Ensono/independent-runner/blob/feature/support-multiple-tf-versions/src/modules/EnsonoBuild/exported/Invoke-Terraform.Tests.ps1#L37-L64



## 🕵️ How to test

Notes for QA