### PR TITLE
fix: Sets TF output depth to 50, customisable

### DIFF
--- a/src/modules/EnsonoBuild/exported/Invoke-Terraform.Tests.ps1
+++ b/src/modules/EnsonoBuild/exported/Invoke-Terraform.Tests.ps1
@@ -283,6 +283,36 @@ Describe "Invoke-Terraform" {
             Should -InvokeVerifiable
             Should -Invoke Invoke-External -Exactly 1
         }
+
+        It "will output TF state in JSON format, custom depth of 2" {
+            Mock `
+                -Command Invoke-External `
+                -Verifiable `
+                -MockWith { return "{`"foo`": {`"value`": [[[`"foo`"]]]}}" } `
+                -ParameterFilter { $commands -eq "terraform output -json" }
+
+            $json = Invoke-Terraform -Output -JsonDepth 2
+
+            $json | Should -Be '{"foo":{"value":["System.Object[]"]}}'
+
+            Should -InvokeVerifiable
+            Should -Invoke Invoke-External -Exactly 1
+        }
+
+        It "will output TF state in JSON format, default depth (50)" {
+            Mock `
+                -Command Invoke-External `
+                -Verifiable `
+                -MockWith { return "{`"foo`": {`"value`": [[[`"foo`"]]]}}" } `
+                -ParameterFilter { $commands -eq "terraform output -json" }
+
+            $json = Invoke-Terraform -Output
+
+            $json | Should -Be '{"foo":{"value":[[["foo"]]]}}'
+
+            Should -InvokeVerifiable
+            Should -Invoke Invoke-External -Exactly 1
+        }
     }
 
     Context "Validate" {

--- a/src/modules/EnsonoBuild/exported/Invoke-Terraform.ps1
+++ b/src/modules/EnsonoBuild/exported/Invoke-Terraform.ps1
@@ -121,8 +121,12 @@ function Invoke-Terraform() {
 
         [string]
         # Delimiter to use to split backend config that has been passed as one string
-        $delimiter = ","
+        $delimiter = ",",
 
+        [Parameter(
+            ParameterSetName="output"
+        )]
+        $JsonDepth = 50
     )
 
     # set flag to state if the dir was changed
@@ -264,7 +268,7 @@ function Invoke-Terraform() {
 
                     $yamldata | ConvertTo-Yaml
                 } else {
-                    $data | ConvertTo-Json -Compress
+                    $data | ConvertTo-Json -Depth $JsonDepth -Compress
                 }
             }
         }


### PR DESCRIPTION
# Pull Request Template

## 📲 What

Sets TF output depth to 50, customisable

## 🤔 Why

The default depth of 2 is no good if you have a heavily nested JSON output from Terraform

## 🛠 How

Allows a depth to be set and sets a high 50 depth instead of the default 2

## 👀 Evidence

See tests

## 🕵️ How to test

`taskctl tests`