### PR TITLE
feat: fixes GH Publish to crash if files not found

### DIFF
--- a/build/azuredevops-runner.yml
+++ b/build/azuredevops-runner.yml
@@ -118,8 +118,7 @@ stages:
 
   - stage: Release
     dependsOn: Build
-    # TODO: Uncomment
-    # condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
+    condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
     jobs:
       - job: Publish
         steps:

--- a/build/azuredevops-runner.yml
+++ b/build/azuredevops-runner.yml
@@ -118,7 +118,8 @@ stages:
 
   - stage: Release
     dependsOn: Build
-    condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
+    # TODO: Uncomment
+    # condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
     jobs:
       - job: Publish
         steps:

--- a/build/taskctl/tasks.yaml
+++ b/build/taskctl/tasks.yaml
@@ -83,7 +83,7 @@ tasks:
     command:
       - |
         $ErrorActionPreference = "Stop"
-        Publish-GitHubRelease -artifactsList "EnsonoBuild.psd1","EnsonoBuild.psm1","Independent Runner.pdf"
+        Publish-GitHubRelease -artifactsList "EnsonoBuild.psd1","EnsonoBuild.psm1","Ensono Independent Runner.pdf"
     env:
       generateReleaseNotes: true
       # TODO: Currently handled by ADO pipeline var, captured in Story 4122

--- a/build/taskctl/tasks.yaml
+++ b/build/taskctl/tasks.yaml
@@ -43,9 +43,15 @@ tasks:
 
   tests:coverage_report:
     context: dotnet
-    description: Create HTML report from coverage doc
+    description: Create Cobertura report xml from coverage xml
     command:
       - Invoke-DotNet -Coverage -Pattern pester-coverage.xml -Path /app -Source /app/src/modules/EnsonoBuild -Target /app/outputs/tests
+
+  tests:coverage_report_html:
+    context: dotnet
+    description: Create HTML report from coverage xml
+    command:
+      - Invoke-DotNet -Coverage -Type Html -Pattern Cobertura.xml -Path /app -Source src/modules/EnsonoBuild -Target /app/outputs/tests
 
   tests:fail_on_error:
     context: powershell
@@ -59,20 +65,25 @@ tasks:
     command:
       - Confirm-Environment -Path /app/build/config/stage_envvars.yml
 
-  update:dashboard:
-    context: powershell
-    description: Update the Deployment Dashboard
-    command:
-      - Update-InfluxDashboard
-    # TODO: Currently handled by ADO pipeline var, captured in Story 4122
-    # env:
-    #  PUBLISH_RELEASE: $true
+  # TODO: Re-enable when we have a new Influx
+  # update:dashboard:
+  #   context: powershell
+  #   description: Update the Deployment Dashboard
+  #   command:
+  #     - |
+  #       $ErrorActionPreference = "Stop"
+  #       Update-InfluxDashboard
+  #   # TODO: Currently handled by ADO pipeline var, captured in Story 4122
+  #   # env:
+  #   #  PUBLISH_RELEASE: $true
 
   publish:github:
     context: powershell
     description: Publish Release to GitHub
     command:
-      - Publish-GitHubRelease -artifactsList "EnsonoBuild.psd1","EnsonoBuild.psm1","Independent Runner.pdf"
+      - |
+        $ErrorActionPreference = "Stop"
+        Publish-GitHubRelease -artifactsList "EnsonoBuild.psd1","EnsonoBuild.psm1","Independent Runner.pdf"
     env:
       generateReleaseNotes: true
       # TODO: Currently handled by ADO pipeline var, captured in Story 4122

--- a/build/templates/setup.yaml
+++ b/build/templates/setup.yaml
@@ -3,11 +3,6 @@ parameters:
     type: string
 
 steps:
-  # TODO: Remove
-  # Checkout self irepo
-  - checkout: self
-
-  # Install Taskfile so that the tests can be run
   - task: Bash@3
     displayName: "Install: Taskctl"
     inputs:

--- a/build/templates/setup.yaml
+++ b/build/templates/setup.yaml
@@ -3,7 +3,8 @@ parameters:
     type: string
 
 steps:
-  # Checkout self repo
+  # TODO: Remove
+  # Checkout self irepo
   - checkout: self
 
   # Install Taskfile so that the tests can be run

--- a/src/modules/EnsonoBuild/exported/Publish-GitHubRelease.Tests.ps1
+++ b/src/modules/EnsonoBuild/exported/Publish-GitHubRelease.Tests.ps1
@@ -1,4 +1,4 @@
-Describe "Publish-GitHubRelease" -Tag "Foo" {
+Describe "Publish-GitHubRelease" {
 
     BeforeAll {
 

--- a/src/modules/EnsonoBuild/exported/Publish-GitHubRelease.Tests.ps1
+++ b/src/modules/EnsonoBuild/exported/Publish-GitHubRelease.Tests.ps1
@@ -1,4 +1,4 @@
-Describe "Publish-GitHubRelease" {
+Describe "Publish-GitHubRelease" -Tag "Foo" {
 
     BeforeAll {
 
@@ -15,10 +15,10 @@ Describe "Publish-GitHubRelease" {
 
             # Mock commands
             Mock -CommandName Write-Error -MockWith {} -ParameterFilter { $Message.ToLower().Contains("version") }
-            Mock -CommandName Write-Error -MockWith {} -ParameterFilter { $Message.ToLower().Contains("unable to call api")}
+            Mock -CommandName Write-Error -MockWith {} -ParameterFilter { $Message.ToLower().Contains("unable to call api") }
             Mock -CommandName Write-Information -MockWith {}
 
-            Mock -CommandName Invoke-WebRequest -MockWith { throw "Unable to call API" } -ParameterFilter { $Uri.AbsoluteUri.ToLower().Contains("api.github.com/repos/amido/pester")}
+            Mock -CommandName Invoke-WebRequest -MockWith { throw "Unable to call API" } -ParameterFilter { $Uri.AbsoluteUri -eq "https://api.github.com/repos/Ensono/pester/releases" }
         }
 
         BeforeEach {
@@ -61,7 +61,7 @@ Describe "Publish-GitHubRelease" {
             $splat = @{
                 version = "100.98.99"
                 commitId = "hjggh66"
-                owner = "amido"
+                owner = "Ensono"
                 apiKey = "1245356"
                 repository = "pester"
                 artifactsDir = $testfolder
@@ -72,6 +72,126 @@ Describe "Publish-GitHubRelease" {
 
             Should -Invoke -CommandName Invoke-WebRequest -Times 1
             Should -Invoke -CommandName Write-Error -Times 1
+        }
+    }
+
+    Context "Errors will be thrown (artefact handling)" {
+
+        BeforeEach {
+
+            # Create a folder to use for each test
+            $testFolder = (New-Item 'TestDrive:\folder' -ItemType Directory).FullName
+        }
+
+        AfterEach {
+
+            Remove-Item -Path $testFolder -Recurse -Force
+        }
+
+        It "if file does not exist, should error" {
+
+            Mock `
+                -CommandName Get-ChildItem `
+                -MockWith { throw } `
+                -ParameterFilter { $Path -eq $testFolder -and $Filter -eq "foo.ps1" -and $ErrorAction -eq "Stop" } `
+                -Verifiable
+
+            Mock `
+                -CommandName Get-ChildItem `
+                -MockWith { } `
+                -Verifiable
+
+            Mock `
+                -CommandName Write-Host `
+                -MockWith { } `
+                -Verifiable
+
+            Mock `
+                -CommandName Write-Error `
+                -MockWith { "fail" >2 } `
+                -Verifiable
+
+            Mock `
+                -CommandName Invoke-WebRequest `
+                -MockWith { } `
+
+            $splat = @{
+                version = "100.98.99"
+                commitId = "hjggh66"
+                owner = "Ensono"
+                apiKey = "1245356"
+                repository = "pester"
+                artifactsDir = $testfolder
+                artifactsList = @("foo.ps1", "bar.ps1")
+                publishRelease = $true
+            }
+
+            Publish-GitHubRelease @splat
+
+            Should -InvokeVerifiable
+            Should -Invoke -CommandName Write-Error -Times 1 -ParameterFilter { $Message -eq "One or more of the files can't be found..! See above for the files not found..." }
+            Should -Invoke -CommandName Get-ChildItem -Times 2
+            Should -Invoke -CommandName Invoke-WebRequest -Times 0
+        }
+
+        It "if file exists, will error if there is an issue talking to the GitHub API for artefact uploading" {
+
+            Mock `
+                -CommandName Get-ChildItem `
+                -MockWith { $Filter } `
+                -Verifiable
+
+            Mock `
+                -CommandName Write-Error `
+                -MockWith { "fail" >2 } `
+                -Verifiable
+
+            Mock `
+                -CommandName Invoke-WebRequest `
+                -MockWith { return @{content = @"
+                {
+                    "upload_url": "https://api.github.com/repo/upload"
+                }
+"@
+                } } `
+                -ParameterFilter { $Uri.AbsoluteUri -eq "https://api.github.com/repos/Ensono/pester/releases" } `
+                -Verifiable
+
+            Mock `
+                -CommandName Invoke-WebRequest `
+                -MockWith { throw } `
+                -Verifiable
+
+            # bar.ps1 uploads successfully
+            Mock `
+                -CommandName Invoke-WebRequest `
+                -MockWith { "uploaded" } `
+                -ParameterFilter { $InFile -eq "bar.ps1" } `
+                -Verifiable
+
+            Mock `
+                -CommandName Get-Item `
+                -MockWith { "Some amazing content" } `
+                -Verifiable
+
+            $splat = @{
+                version = "100.98.99"
+                commitId = "hjggh66"
+                owner = "Ensono"
+                apiKey = "1245356"
+                repository = "pester"
+                artifactsDir = $testfolder
+                artifactsList = @("foo.ps1", "bar.ps1")
+                publishRelease = $true
+            }
+
+            Publish-GitHubRelease @splat
+
+            Should -InvokeVerifiable
+            Should -Invoke -CommandName Get-ChildItem -Times 2
+            Should -Invoke -CommandName Invoke-WebRequest -Times 3
+            Should -Invoke -CommandName Write-Error -Times 1 -ParameterFilter { $Message -eq "An error has occured, cannot upload foo.ps1: ScriptHalted" }
+            Should -Invoke -CommandName Write-Error -Times 0 -ParameterFilter { $Message -eq "An error has occured, cannot upload bar.ps1: ScriptHalted" }
         }
     }
 
@@ -112,7 +232,7 @@ Describe "Publish-GitHubRelease" {
             $splat = @{
                 version = "100.98.99"
                 commitId = "hjggh66"
-                owner = "amido"
+                owner = "Ensono"
                 apiKey = "1245356"
                 repository = "pester"
                 artifactsDir = $testfolder
@@ -130,7 +250,7 @@ Describe "Publish-GitHubRelease" {
             $splat = @{
                 version = "100.98.99"
                 commitId = "hjggh66"
-                owner = "amido"
+                owner = "Ensono"
                 apiKey = "1245356"
                 repository = "pester"
                 artifactsDir = $testfolder

--- a/src/modules/EnsonoBuild/exported/Publish-GitHubRelease.ps1
+++ b/src/modules/EnsonoBuild/exported/Publish-GitHubRelease.ps1
@@ -181,7 +181,6 @@ function Publish-GitHubRelease() {
         try {
             $result = Invoke-WebRequest @uploadArgs
         } catch {
-            $_.Exception.Message >> fool
             Write-Error ("An error has occured, cannot upload {0}: {1}" -f $uploadFile, $_.Exception.Message)
             continue
         }

--- a/src/modules/EnsonoBuild/exported/Publish-GitHubRelease.ps1
+++ b/src/modules/EnsonoBuild/exported/Publish-GitHubRelease.ps1
@@ -1,4 +1,3 @@
-
 function Publish-GitHubRelease() {
 
     <#
@@ -98,7 +97,13 @@ function Publish-GitHubRelease() {
 
         foreach ($file in $files) {
             try {
-                $artifactsList += , (Get-ChildItem -Path $artifactsDir -Recurse -Filter $file -ErrorAction "Stop")
+                $artifact = Get-ChildItem -Path $artifactsDir -Recurse -Filter $file -ErrorAction "Stop"
+
+                if ($null -eq $artifact) {
+                    throw
+                }
+
+                $artifactsList += , $artifact
             # Get-ChildItem errors to the terminal rather than throwing a typed Exception
             } catch {
                 $fileError = $true

--- a/src/modules/EnsonoBuild/exported/Update-InfluxDashboard.ps1
+++ b/src/modules/EnsonoBuild/exported/Update-InfluxDashboard.ps1
@@ -7,7 +7,7 @@ function Update-InfluxDashboard() {
 
     .DESCRIPTION
     With pielines being defined as code, it has become more difficult to show visually what applications have
-    been deployed in what environment. This cmdlet uses InfluxDB to create a dashboard of applications and 
+    been deployed in what environment. This cmdlet uses InfluxDB to create a dashboard of applications and
     which version has been deployed into each environment.
 
     This function will send data to an InfluxDB (a time based database) so that a dahsboard can be generated. This
@@ -59,15 +59,13 @@ function Update-InfluxDashboard() {
         Write-Information -MessageData ("Neither publishRelease parameter nor PUBLISH_RELEASE environment variable set to `'true`', exiting.")
         return
     }
-    
+
     # Validate all parameters are supplied
     $result = Confirm-Parameters -list @("measurement", "tags", "version", "influx_server", "influx_token", "influx_org", "influx_bucket")
     if (!$result) {
         Write-Error -Message "Missing parameters"
         return
     }
-
-
 
     # Confirm influx server is HTTPS web address
     $result = $false
@@ -101,7 +99,7 @@ function Update-InfluxDashboard() {
 
     # Generate the request URI
     $uri = "{0}/api/v2/write?org={1}&bucket={2}" -f $influx_server,$influx_org,$influx_bucket
-    
+
     Write-Information -MessageData ("URI: {0}" -f $uri)
 
     # Generate the headers
@@ -114,9 +112,9 @@ function Update-InfluxDashboard() {
     $object = ,"$measurement" + $object
     $tags = $object -join ","
     $body = "$tags" + " version=`"$version`""
-    
+
     # Invoke-RestMethod on InfluxDB endpoint
-    try     { Invoke-RestMethod -Method POST -Header $headers -uri $uri -body $body 
+    try     { Invoke-RestMethod -Method POST -Header $headers -uri $uri -body $body
             Write-Information "InfluxDB Updated" }
     catch   { Write-Error $_
             return }

--- a/taskctl.yaml
+++ b/taskctl.yaml
@@ -24,9 +24,10 @@ pipelines:
 
   release:
     - task: setup:environment
-    - task: update:dashboard
-      depends_on:
-        - setup:environment
+    # TODO: Re-enable when we have a new Influx
+    # - task: update:dashboard
+    #   depends_on:
+    #     - setup:environment
     - task: publish:github
       depends_on:
         - setup:environment


### PR DESCRIPTION
# Pull Request Template

## 📲 What

Fixes GH Release to error if artefacts don't exist and fail. Adds the functionality and tests surrounding this, plus adds a test for existing behaviour not covered (failure to upload an artefact).

## 🤔 Why

If artefacts didn't exist it'd carry on regardless which isn't what we want. This doesn't stop if no artefacts are specified, i.e. it doesn't fail if there's no filter but an artefacts dir is specified.

## 🛠 How

## 👀 Evidence

Published release without Artefacts and didn't fail:
![image](https://github.com/user-attachments/assets/887391dd-e2a4-4e78-ad48-c4b776a8aa4c)

New behaviour fails if files can't be found:
![image](https://github.com/user-attachments/assets/130b7ff6-6624-4ef7-87f2-c71f18dc2b87)

Published Artefacts:
![image](https://github.com/user-attachments/assets/7291b71a-0cfa-422b-98cb-d8f0e2ba9280)


## 🕵️ How to test