### PR TITLE
fix: sonar.login is deprecated, use sonar.token

### DIFF
--- a/src/modules/EnsonoBuild/exported/Invoke-SonarScanner.Tests.ps1
+++ b/src/modules/EnsonoBuild/exported/Invoke-SonarScanner.Tests.ps1
@@ -92,7 +92,7 @@ Describe "Invoke-SonarScanner" {
             Invoke-SonarScanner @Splat
 
             # Build up the command that is expected
-            $expected = "*dotnet-sonarscanner* begin /k:{0} /v:{1} /d:sonar.host.url={2} /o:{3} /d:sonar.login={4}" -f `
+            $expected = "*dotnet-sonarscanner* begin /k:{0} /v:{1} /d:sonar.host.url={2} /o:{3} /d:sonar.token={4}" -f `
                 $splat.ProjectName, `
                 $splat.BuildVersion, `
                 $splat.URL, `
@@ -110,7 +110,7 @@ Describe "Invoke-SonarScanner" {
             Invoke-SonarScanner -Start
 
             # Build up the command that is expected
-            $expected = "*dotnet-sonarscanner* begin /k:{0} /v:{1} /d:sonar.host.url={2} /o:{3} /d:sonar.login={4}" -f `
+            $expected = "*dotnet-sonarscanner* begin /k:{0} /v:{1} /d:sonar.host.url={2} /o:{3} /d:sonar.token={4}" -f `
                 $env:PROJECT_NAME, `
                 $env:BUILD_BUILDNUMBER, `
                 $env:SONAR_URL, `
@@ -140,7 +140,7 @@ Describe "Invoke-SonarScanner" {
             Invoke-SonarScanner -Stop -Token 11111
 
             # Check the command that would be executed
-            $Session.commands.list[0] | Should -BeLike "*dotnet-sonarscanner* end /d:sonar.login=11111"
+            $Session.commands.list[0] | Should -BeLike "*dotnet-sonarscanner* end /d:sonar.token=11111"
         }
 
         It "environment vars" {
@@ -148,7 +148,7 @@ Describe "Invoke-SonarScanner" {
             Invoke-SonarScanner -Stop
 
             # Check the command that would be executed
-            $Session.commands.list[0] | Should -BeLike "*dotnet-sonarscanner* end /d:sonar.login=654321"
+            $Session.commands.list[0] | Should -BeLike "*dotnet-sonarscanner* end /d:sonar.token=654321"
         }
     }
 }

--- a/src/modules/EnsonoBuild/exported/Invoke-SonarScanner.ps1
+++ b/src/modules/EnsonoBuild/exported/Invoke-SonarScanner.ps1
@@ -137,7 +137,7 @@ function Invoke-SonarScanner() {
         $arguments += "/v:{0}" -f $BuildVersion
         $arguments += "/d:sonar.host.url={0}" -f $URL
         $arguments += "/o:{0}" -f $Organisation
-        $arguments += "/d:sonar.login={0}" -f $Token
+        $arguments += "/d:sonar.token={0}" -f $Token
         if (![string]::IsNullOrEmpty($Properties)) {
             $arguments += $Properties
         }
@@ -148,7 +148,7 @@ function Invoke-SonarScanner() {
 
     if ($stop.IsPresent) {
         $arguments = @()
-        $arguments += "/d:sonar.login={0}" -f $Token
+        $arguments += "/d:sonar.token={0}" -f $Token
         if (![string]::IsNullOrEmpty($Properties)) {
             $arguments += $Properties
         }


### PR DESCRIPTION
# Pull Request Template

## 📲 What

`sonar.login` is deprecated, use `sonar.token` instead.

What have you implemented?

## 🤔 Why


`sonar.login` is deprecated and issues warnings in SonarCloud.

## 🛠 How

## 👀 Evidence

![image](https://github.com/user-attachments/assets/17765308-4368-4450-964b-21ef617b72ca)

## 🕵️ How to test