### PR TITLE
Update list of exported commands and allowed additional exitcodes on a cmdlet

### DIFF
--- a/src/modules/EnsonoBuild/EnsonoBuild.psd1
+++ b/src/modules/EnsonoBuild/EnsonoBuild.psd1
@@ -82,6 +82,7 @@
         "Expand-Template",
         "Invoke-Asciidoc",
         "Invoke-DotNet",
+        "Invoke-External",
         "Invoke-GitClone",
         "Invoke-Helm",
         "Invoke-Inspec",
@@ -95,6 +96,7 @@
         "Publish-Confluence",
         "Publish-GitHubRelease",
         "Set-Config",
+        "Stop-Task",
         "Update-BuildNumber",
         "Update-InfluxDashboard"
     )

--- a/src/modules/EnsonoBuild/exported/Invoke-Asciidoc.ps1
+++ b/src/modules/EnsonoBuild/exported/Invoke-Asciidoc.ps1
@@ -106,7 +106,12 @@ function Invoke-Asciidoc() {
         [string]
         [ValidateSet('info', 'warn', 'warning', 'error', 'fatal')]
         # A level of logging which will trigger a failed exit code
-        $failureLevel = "warn"
+        $failureLevel = "warn",
+
+        [Int[]]
+        # List of exit codes that are accepatable
+        # Zero is always accepted
+        $ExitCodes = @()
     )
 
     # Define variables to be used in the function
@@ -228,7 +233,7 @@ function Invoke-Asciidoc() {
     $cmd = "{0} {1} {2}" -f ($cmdline -join " "), (Replace-Tokens -Tokens $tokens $settings.path), "--failure-level ${failureLevel}"
 
     # Execute the command
-    Invoke-External -Command $cmd
+    Invoke-External -Command $cmd -AdditionalExitCodes $ExitCodes
 
     # Output the exitcode of the command
     $LASTEXITCODE


### PR DESCRIPTION
## 📲 What

Added `Invoke-Extnernal` and `Stop-Task` to the PSD1 file so that they are exported when the module is loaded.

Added `ExitCodes` as an argument to `Invoke-AsciiDoc` so they can be passed to `Invoke-External` to ignore certain ones.

## 🤔 Why

Although the cmdlets were in the `exported` folder this does not export them by default. The module data file needs to be updated with the cmdlet. This is done automatically with a formal build. but if running locally they will not be exported.

Need to be able to permit extra exit codes when running `Invoke-AsciiDoc`

## 🛠 How

Added the two cmdlets to the `FunctionsToExport` list in the `EnsonoBuild.psd1` file.

Created a new parameter for `Invoke-AsciiDoc` to accept additional exit codes and then pass that as `AdditionalExitcodes` to `Invoke-External`.

## 👀 Evidence

Link to builds/artifacts/etc.

## 🕵️ How to test

Notes for QA