### PR TITLE
fix: removes exportAs key

### DIFF
--- a/build/taskctl/tasks.yaml
+++ b/build/taskctl/tasks.yaml
@@ -21,7 +21,6 @@ tasks:
     description: Update the build number
     command:
       - Update-BuildNumber
-    exportAs: BUILDNUMBER
 
   _docs:
     description: Build Docs


### PR DESCRIPTION
# Pull Request Template

## 📲 What

Removes `exportAs` as it's not being used we think, and it's no longer in `taskctl`.

## 🤔 Why

To fix the local builds

## 🛠 How

## 👀 Evidence

## 🕵️ How to test

Notes for QA