### PR TITLE
fix: version passed in correctly to module gen

### DIFF
--- a/build/config/stage_envvars.yml
+++ b/build/config/stage_envvars.yml
@@ -1,8 +1,6 @@
 default:
   variables:
-
 stages:
-
   - name: build
     variables:
       - name: MODULE_VERSION

--- a/build/taskctl/contexts.yaml
+++ b/build/taskctl/contexts.yaml
@@ -67,8 +67,8 @@ contexts:
     envfile:
       generate: true
       exclude:
-        - home
-        - path
+        - HOME
+        - PATH
 
   dotnet:
     executable:

--- a/build/taskctl/tasks.yaml
+++ b/build/taskctl/tasks.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Ensono/taskctl/refs/heads/master/schemas/schema_v1.json
 tasks:
   image-pull:
     context: powershell
@@ -32,7 +33,7 @@ tasks:
     context: powershell
     description: Build the local PowerShell module
     command:
-      - Build-PowerShellModule -Path /app/src/modules -name EnsonoBuild -target /app/outputs/module
+      - Build-PowerShellModule -Path /app/src/modules -name EnsonoBuild -target /app/outputs/module -version ${env:BUILD_BUILDNUMBER}
 
   tests:unit:
     context: powershell_test

--- a/src/modules/EnsonoBuild/exported/Build-PowerShellModule.ps1
+++ b/src/modules/EnsonoBuild/exported/Build-PowerShellModule.ps1
@@ -89,7 +89,7 @@ function Build-PowerShellModule() {
         Write-Error -Message ("Module data file cannot be found: {0}" -f $modulePSD)
         return $false
     }
-    
+
     # Get all the functions in the module, except the tests
     $splat = @{
         Path = $moduleDir


### PR DESCRIPTION
# Pull Request Template

## 📲 What

Passes in the version to the module generation


## 🤔 Why

Currently the module always shows `0.1` as the version which isn't helpful for debugging the installed version.

![image](https://github.com/user-attachments/assets/4220451c-33f1-47d4-ac67-cc478b8a9f52)

## 🛠 How

## 👀 Evidence

## 🕵️ How to test